### PR TITLE
fix: imports order

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   "browser": "./dist/index.min.js",
   "jsdelivr": "./dist/index.umd.js",
   "exports": {
-    "require": {
-      "default": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+    "require": {      
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.cjs"
     },
-    "import": {
-      "default": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+    "import": {      
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "browser": "./dist/index.min.js",
   "jsdelivr": "./dist/index.umd.js",
   "exports": {
-    "require": {      
+    "require": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.cjs"
     },
-    "import": {      
+    "import": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.mjs"
     }


### PR DESCRIPTION
## Issue

Importing rampensau version 0.14.x into a TypeScript project fails with the following error:

```
Module not found: Default condition should be last one
 ```
 
 This issue did not occur in version 0.13.x.
 
 ## Steps to reproduce
 
 1. Create or use an existing TypeScript project.
 2. Install rampensau version 0.14.x.
 3. Attempt to import the module in a TypeScript file:
 
 ```
 import { colorToCSS, generateColorRamp } from "rampensau";
 ```
 
 4. Run the project build or start the project.
 
 ## Expected results

The project should compile and run successfully without any errors, as it did with version 0.13.x.

## Actual results

The build fails with the following error message:

```
Module not found: Default condition should be last one
```

## Note

The only notable change between versions 0.13.x and 0.14.x is the introduction of TypeScript types. The issue appears to be related to the ordering of conditions in the package’s "exports" field, which was introduced or modified in 0.14.x.

Also, this change should be tested.

## Update

I just tested this patch on my Typescript project and it now compiles.